### PR TITLE
Add a second json object to examples

### DIFF
--- a/content/configuration/data-selection.md
+++ b/content/configuration/data-selection.md
@@ -223,7 +223,6 @@ The following are examples of valid Modbus TCP data selection configurations.
         "ConversionOffset": 14.6,
         "DataFilterId" : "DataFilter2"
     }    
-}
 ]
 ```
 

--- a/content/configuration/data-selection.md
+++ b/content/configuration/data-selection.md
@@ -4,7 +4,7 @@ uid: PIAdapterForModbusTCPDataSelectionConfiguration
 
 # Data selection
 
-TEST TEST In addition to the data source configuration, you need to provide a data selection configuration to specify the data you want the adapter to collect from the data sources.
+In addition to the data source configuration, you need to provide a data selection configuration to specify the data you want the adapter to collect from the data sources.
 
 ## Configure Modbus TCP data selection
 
@@ -172,20 +172,19 @@ The following are examples of valid Modbus TCP data selection configurations.
         "Selected" : true,
         "UnitId": 1,
         "RegisterType": 3,
-        "RegisterOffset": 122,
-        "DataTypeCode": 20,
+        "RegisterOffset": 0,
+        "DataTypeCode": 10,
         "ScheduleId": "Schedule1"
     },
     {
         "DeviceId" : "Device2",
         "Selected" : true,
-        "UnitId": 5,
-        "RegisterType": 2,
-        "RegisterOffset": 122,
-        "DataTypeCode": 30,
-        "ScheduleId": "Schedule2" 
+        "UnitId": 1,
+        "RegisterType": 3,
+        "RegisterOffset": 1,
+        "DataTypeCode": 10,
+        "ScheduleId": "Schedule2"
     }
-
 ]
 ```
 
@@ -196,11 +195,11 @@ The following are examples of valid Modbus TCP data selection configurations.
     {
         "DeviceId" : "Device1",
         "Selected": true,
-        "Name": "MyDataItem",
+        "Name": "MyDataItem1",
         "UnitId": 1,
         "RegisterType": 3,
-        "RegisterOffset": 122,
-        "DataTypeCode": 20,
+        "RegisterOffset": 0,
+        "DataTypeCode": 10,
         "ScheduleId": "Schedule1",
         "StreamId": "stream.1",
         "BitMap": "020301",
@@ -209,20 +208,20 @@ The following are examples of valid Modbus TCP data selection configurations.
         "DataFilterId" : "DataFilter1"
     },
     {
-        "DeviceId" : "Device2",
+        "DeviceId" : "Device1",
         "Selected": true,
-        "Name": "MyNewDataItem",
-        "UnitId": 5,
-        "RegisterType": 2,
-        "RegisterOffset": 122,
-        "DataTypeCode": 30,
+        "Name": "MyDataItem2",
+        "UnitId": 1,
+        "RegisterType": 3,
+        "RegisterOffset": 1,
+        "DataTypeCode": 10,
         "ScheduleId": "Schedule2",
         "StreamId": "stream.2",
-        "BitMap": "020302",
-        "ConversionFactor": 12.4,
-        "ConversionOffset": 14.6,
+        "BitMap": "020301",
+        "ConversionFactor": 12.3,
+        "ConversionOffset": 14.5,
         "DataFilterId" : "DataFilter2"
-    }    
+    }
 ]
 ```
 

--- a/content/configuration/data-selection.md
+++ b/content/configuration/data-selection.md
@@ -87,6 +87,8 @@ When reading from function codes `1` and `2`, the adapter expects these to be re
 
 ### DataTypeCode
 
+The following tables list all the DataTypeCodes supported in the adapter.
+
 #### DataTypeCode 1
 
 | Name          | Value Type | Register Type | Meaning | Output Type | Interface data type code |
@@ -173,7 +175,17 @@ The following are examples of valid Modbus TCP data selection configurations.
         "RegisterOffset": 122,
         "DataTypeCode": 20,
         "ScheduleId": "Schedule1"
+    },
+    {
+        "DeviceId" : "Device2",
+        "Selected" : true,
+        "UnitId": 5,
+        "RegisterType": 2,
+        "RegisterOffset": 122,
+        "DataTypeCode": 30,
+        "ScheduleId": "Schedule2" 
     }
+
 ]
 ```
 
@@ -187,7 +199,7 @@ The following are examples of valid Modbus TCP data selection configurations.
         "Name": "MyDataItem",
         "UnitId": 1,
         "RegisterType": 3,
-        "RegisterOffset": 123,
+        "RegisterOffset": 122,
         "DataTypeCode": 20,
         "ScheduleId": "Schedule1",
         "StreamId": "stream.1",
@@ -195,7 +207,23 @@ The following are examples of valid Modbus TCP data selection configurations.
         "ConversionFactor": 12.3,
         "ConversionOffset": 14.5,
         "DataFilterId" : "DataFilter1"
-    }
+    },
+    {
+        "DeviceId" : "Device2",
+        "Selected": true,
+        "Name": "MyNewDataItem",
+        "UnitId": 5,
+        "RegisterType": 2,
+        "RegisterOffset": 122,
+        "DataTypeCode": 30,
+        "ScheduleId": "Schedule2",
+        "StreamId": "stream.2",
+        "BitMap": "020302",
+        "ConversionFactor": 12.4,
+        "ConversionOffset": 14.6,
+        "DataFilterId" : "DataFilter2"
+    }    
+}
 ]
 ```
 


### PR DESCRIPTION
Hi @zryska, I added a second json object to the Modbus data selection examples because the single object must have caused confusion. Do you mind taking a look to make sure that it looks right? Thank you!