### PR TITLE
Updated to add Network Proxy

### DIFF
--- a/content/toc.yml
+++ b/content/toc.yml
@@ -19,14 +19,15 @@
   - topicUid: SchedulesConfiguration
   - topicUid: PIAdapterForModbusTCPDataSelectionConfiguration
   - topicUid: DataFiltersConfiguration
+  - topicUid: EgressEndpointsConfiguration
+    items:
+    - topicUid: PrepareEgressDestinations
+    - topicUid: ConfigureANetworkProxy
   - topicUid: GeneralConfiguration
     items:
     - topicUid: AdapterMetadata
   - topicUid: BufferingConfiguration
   - topicUid: LoggingConfiguration
-  - topicUid: EgressEndpointsConfiguration
-    items:
-    - topicUid: PrepareEgressDestinations 
   - topicUid: HealthEndpointConfiguration
   - topicUid: PIAdapterForModbusTCPConfigurationExamples
 - topicUid: Administration


### PR DESCRIPTION
Updated the TOC to add Network Proxy information (ConfigureANetworkProxy) to the TOC. Also, for consistency, moved the topics in the Configuration section to mirror the BACnet Configuration section